### PR TITLE
Fixed messed up pip command in notebook

### DIFF
--- a/notebooks/stablelm_alpha.ipynb
+++ b/notebooks/stablelm_alpha.ipynb
@@ -36,7 +36,7 @@
       "outputs": [],
       "source": [
         "!pip install -U pip\n",
-        "!pip accelerate bitsandbytes transformers"
+        "!pip install accelerate bitsandbytes transformers"
       ]
     },
     {


### PR DESCRIPTION
Fixed issue with one cell in notebook.

Was:
```
!pip install -U pip
!pip accelerate bitsandbytes transformers
```

Fixed version:
```
!pip install -U pip
!pip install accelerate bitsandbytes transformers
```