### PR TITLE
Match notebook name to Colab link

### DIFF
--- a/notebooks/stablelm-alpha.ipynb
+++ b/notebooks/stablelm-alpha.ipynb
@@ -9,7 +9,7 @@
       "source": [
         "# StableLM-Alpha\n",
         "\n",
-        "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/Stability-AI/StableLM/blob/main/notebooks/stablelm_alpha.ipynb)\n",
+        "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/Stability-AI/StableLM//blob/main/notebooks/stablelm-alpha.ipynb)\n",
         "\n",
         "<img src=\"https://raw.githubusercontent.com/Stability-AI/StableLM/main/assets/mascot.png?token=GHSAT0AAAAAABWTZAV7EFSADKXWO3HDNKPYZBZ6Z7A\"/>\n",
         "\n",


### PR DESCRIPTION
The Colab link has a dash not an underscore. Dash looks better, so I renamed the file.